### PR TITLE
TOTP Encryption Within Configuration

### DIFF
--- a/lib/session.go
+++ b/lib/session.go
@@ -7,12 +7,10 @@ import (
 	"net"
 	"sync"
 
-	_ "github.com/pquerna/otp/totp"
 	"github.com/satori/go.uuid"
 	"go.uber.org/zap"
 	"golang.org/x/crypto/ssh"
 	"golang.org/x/crypto/ssh/agent"
-	_ "golang.org/x/crypto/ssh/terminal"
 )
 
 // An account key represents a mapping of ssh public key to account


### PR DESCRIPTION
This PR adds code which will now encrypt/decrypt TOTP keys within the configuration, allowing us to store the full accounts.json in an untrusted or semi-trusted location. The motivation behind this is to allow users (specifically us over at Discord) to safely track their accounts.json within git. This flow is much cleaner for adding new users, as they can do it OOB of the bastion.

I've thought through the security aspects of this and can't really see a downside other than the obvious linkage between password and TOTP, which I don't think in this case opens any vulnerabilities.